### PR TITLE
Gear sets

### DIFF
--- a/database/gearsets.go
+++ b/database/gearsets.go
@@ -6,56 +6,132 @@ import (
 	"github.com/alyjay/xiv-be/types"
 )
 
-func InsertGearSet(g types.GearSet) (err error) {
+func InsertGearPiece(pieces []types.GearPieceRow, gsId string) (err error) {
+
+	db, err := GetDb()
+	if err != nil {
+		return err
+	}
+
+	req, err := db.NamedQuery(`
+			INSERT INTO gear_pieces (
+				slot,
+				source,
+				have,
+				augmented,
+				priority
+			) VALUES (
+			 	:slot,
+				:source,
+				:have,
+				:augmented,
+				:priority
+			 ) RETURNING *;
+		`, pieces)
+	if err != nil {
+		return err
+	}
+	for req.Next() {
+		var id types.GearPieceRow
+		req.StructScan(&id)
+		_, err = db.Exec(`
+			INSERT INTO gear_sets_gear_pieces (
+				gear_set_id,
+				gear_piece_id,
+				gear_piece_slot
+			) VALUES (
+			 $1,
+			 $2,
+			 $3
+			)
+		`, gsId, id.Id, id.Slot)
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+func InsertGearSetV2(g types.GearSetV2) (err error) {
+
 	db, err := GetDb()
 
 	if err != nil {
 		return err
 	}
 
-	items, err := json.Marshal(g.Items)
-	if err != nil {
-		return err
-	}
-
-	gs := types.GearSetRow{
-		GearSet: g,
-		Items:   items,
-	}
-
 	_, err = db.NamedExec(`
-	INSERT INTO gear_sets (
-		id,
-		user_id,
-		character_id,
-		name,
-		job,
-		config,
-		index
-	) VALUES (
+		INSERT INTO gear_sets (
+			id,
+			user_id,
+			character_id,
+			name,
+			job,
+			index
+		) VALUES (
 		 :id,
 		 :user_id,
 		 :character_id,
 		 :name,
 		 :job,
-		 :config,
 		 :index
-	)
-	`, gs)
+		 )
+	`, g)
+
+	if err != nil {
+		return err
+	}
+
+	pieces := ConvertPieceMapToRow(g.Items)
+	err = InsertGearPiece(pieces, g.ID)
 
 	return err
 }
 
-func SelectGearSetsForCharacter(id string, archived bool) (gs []types.GearSet, err error) {
+func GetConfig(id string) (gs types.ItemsV2, err error) {
+	db, err := GetDb()
+	if err != nil {
+		return nil, err
+	}
+
+	query := db.QueryRow(`
+		SELECT config from gear_sets WHERE id = $1
+	`, id)
+
+	var jsonData []byte
+	err = query.Scan(&jsonData)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(jsonData, &gs)
+
+	return gs, err
+}
+
+func ConvertPieceMapToRow(pieces types.ItemsV2) (rows []types.GearPieceRow) {
+	for key, value := range pieces {
+		rows = append(rows, types.GearPieceRow{
+			GearPiece: value,
+			Slot:      key,
+		})
+
+	}
+	return rows
+}
+
+func SelectGearSetsForCharacterV2(id string, archived bool) (gs []types.GearSetV2, err error) {
 	db, err := GetDb()
 
 	if err != nil {
-		return gs, err
+		return nil, err
 	}
 
 	err = db.Select(&gs, `
 	SELECT 
-		id, name, job, config
+		id, name, job
 	FROM gear_sets WHERE
 		character_id = $1
 	AND
@@ -63,37 +139,84 @@ func SelectGearSetsForCharacter(id string, archived bool) (gs []types.GearSet, e
 	ORDER BY index ASC
 	`, id, archived)
 
-	return gs, err
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []types.GearSetV2
+
+	for _, k := range gs {
+		var Items []types.GearPieceRow
+		err = db.Select(&Items, `
+			SELECT 
+				p.id, 
+				p.source, 
+				p.have, 
+				p.augmented, 
+				p.priority, 
+				p.slot 
+			FROM gear_pieces p
+			JOIN gear_sets_gear_pieces r
+			ON r.gear_piece_id = p.id
+			WHERE r.gear_set_id = $1
+		`, k.ID)
+		k.Items = make(map[types.Slot]types.GearPiece)
+		if len(Items) < 11 {
+			k.Items, err = GetConfig(k.ID)
+			pieces := ConvertPieceMapToRow(k.Items)
+			InsertGearPiece(pieces, k.ID)
+		} else {
+			for _, l := range Items {
+				k.Items[l.Slot] = l.GearPiece
+			}
+		}
+
+		ret = append(ret, k)
+
+	}
+
+	return ret, err
 }
 
-func UpdateGearSet(g ...types.GearSet) (err error) {
+func UpdateGearSetV2(g types.GearSetV2) (err error) {
 	db, err := GetDb()
 
 	if err != nil {
 		return err
-	}
-	var gs []types.GearSetRow
-
-	for _, s := range g {
-		items, err := json.Marshal(s.Items)
-		if err != nil {
-			return err
-		}
-		gs = append(gs, types.GearSetRow{
-			GearSet: s,
-			Items:   items,
-		})
 	}
 
 	_, err = db.NamedExec(`
 		UPDATE gear_sets SET
 			name = :name,
 			job = :job,
-			config = :config,
 			index = :index,
 			archived = :archived
 		WHERE id = :id AND character_id = :character_id
-	`, gs)
+	`, g)
+
+	pieces := ConvertPieceMapToRow(g.Items)
+	for _, piece := range pieces {
+		_, err = db.NamedExec(`
+			UPDATE gear_pieces SET
+				have = :have,
+				augmented = :augmented,
+				priority = :priority
+			WHERE id = :id AND slot = :slot
+		`, piece)
+		if err != nil {
+			return err
+		}
+		_, err = db.Exec(`
+			UPDATE gear_sets_gear_pieces SET
+				gear_piece_id = $1
+			WHERE 
+				gear_set_id = $2 AND
+				gear_piece_slot = $3
+		`, piece.Id, g.ID, piece.Slot)
+		if err != nil {
+			return err
+		}
+	}
 
 	return err
 }

--- a/database/migrations/000006_gear_piece.down.sql
+++ b/database/migrations/000006_gear_piece.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS gear_sets_gear_pieces;
+
+DROP TABLE IF EXISTS gear_pieces;

--- a/database/migrations/000006_gear_piece.up.sql
+++ b/database/migrations/000006_gear_piece.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE
+    IF NOT EXISTS gear_pieces (
+        id serial primary key,
+        slot INTEGER,
+        source INTEGER,
+        have BOOLEAN,
+        augmented BOOLEAN,
+        priority INTEGER
+    );
+
+CREATE TABLE
+    IF NOT EXISTS gear_sets_gear_pieces (
+        gear_set_id uuid REFERENCES gear_sets (id) ON DELETE CASCADE,
+        gear_piece_id integer REFERENCES gear_pieces (id) ON DELETE CASCADE
+    );

--- a/database/migrations/000006_gear_piece.up.sql
+++ b/database/migrations/000006_gear_piece.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE
+    IF NOT EXISTS gear_pieces (
+        id serial primary key,
+        slot INTEGER,
+        source INTEGER,
+        have BOOLEAN,
+        augmented BOOLEAN,
+        priority INTEGER
+    );
+
+CREATE TABLE
+    IF NOT EXISTS gear_sets_gear_pieces (
+        gear_set_id uuid REFERENCES gear_sets (id) ON DELETE CASCADE,
+        gear_piece_id integer REFERENCES gear_pieces (id) ON DELETE CASCADE,
+        gear_piece_slot integer,
+        PRIMARY KEY (gear_set_id, gear_piece_slot)
+    );

--- a/gearset/gearset.go
+++ b/gearset/gearset.go
@@ -20,14 +20,14 @@ func SetUpGearSetRoutes(r *mux.Router) {
 }
 
 func AddGearSet(w http.ResponseWriter, r *http.Request) {
-	var req types.GearSet
+	var req types.GearSetV2
 	_ = json.NewDecoder(r.Body).Decode(&req)
 
 	characterId := mux.Vars(r)["characterId"]
 
 	newUUID := uuid.NewString()
 
-	err := database.InsertGearSet(types.GearSet{
+	err := database.InsertGearSetV2(types.GearSetV2{
 		ID:          newUUID,
 		UserId:      req.UserId,
 		CharacterId: characterId,
@@ -52,9 +52,9 @@ func GetGearSets(w http.ResponseWriter, r *http.Request) {
 	archived := r.URL.Query().Has("archived")
 
 	characterId := mux.Vars(r)["characterId"]
-	var Sets []types.GearSet
+	var Sets []types.GearSetV2
 
-	Sets, err := database.SelectGearSetsForCharacter(characterId, archived)
+	Sets, err := database.SelectGearSetsForCharacterV2(characterId, archived)
 	if err != nil {
 		response.InternalServerError(w, err.Error())
 		return
@@ -66,7 +66,7 @@ func GetGearSets(w http.ResponseWriter, r *http.Request) {
 
 func UpdateGearSet(w http.ResponseWriter, r *http.Request) {
 
-	var req types.GearSet
+	var req types.GearSetV2
 	_ = json.NewDecoder(r.Body).Decode(&req)
 
 	id := mux.Vars(r)["id"]
@@ -74,7 +74,7 @@ func UpdateGearSet(w http.ResponseWriter, r *http.Request) {
 	req.CharacterId = characterId
 	req.ID = id
 
-	err := database.UpdateGearSet(req)
+	err := database.UpdateGearSetV2(req)
 
 	if err != nil {
 		response.InternalServerError(w, err.Error())
@@ -96,11 +96,11 @@ func DeleteGearSet(w http.ResponseWriter, r *http.Request) {
 func BulkUpdateGearSets(w http.ResponseWriter, r *http.Request) {
 	characterId := mux.Vars(r)["characterId"]
 
-	var req []types.GearSet
+	var req []types.GearSetV2
 	_ = json.NewDecoder(r.Body).Decode(&req)
 
 	for i, s := range req {
-		database.UpdateGearSet(types.GearSet{
+		database.UpdateGearSetV2(types.GearSetV2{
 			ID:          s.ID,
 			Name:        s.Name,
 			Job:         s.Job,

--- a/types/gearset.go
+++ b/types/gearset.go
@@ -59,9 +59,16 @@ const (
 )
 
 type GearPiece struct {
-	Source    Source `json:"source"`
-	Have      bool   `json:"have"`
-	Augmented bool   `json:"augmented,omitempty"`
+	Id        int    `json:"id" db:"id"`
+	Source    Source `json:"source" db:"source"`
+	Have      bool   `json:"have" db:"have"`
+	Augmented bool   `json:"augmented,omitempty" db:"augmented"`
+	Priority  int    `json:"priority" db:"priority"`
+}
+
+type GearPieceRow struct {
+	GearPiece
+	Slot Slot `json:"slot" db:"slot"`
 }
 
 type Items map[int]interface {
@@ -75,6 +82,8 @@ func (i *Items) Scan(val interface{}) error {
 	case string:
 		json.Unmarshal([]byte(v), &i)
 		return nil
+	case nil:
+		return nil
 	default:
 		return fmt.Errorf("unsupported type %T", v)
 	}
@@ -83,6 +92,8 @@ func (i *Items) Scan(val interface{}) error {
 func (i *Items) Value() (driver.Value, error) {
 	return json.Marshal(i)
 }
+
+type ItemsV2 = map[Slot]GearPiece
 
 type GearSet struct {
 	Archived    bool   `json:"archived" db:"archived"`
@@ -93,6 +104,17 @@ type GearSet struct {
 	Name        string `json:"name" db:"name"`
 	UserId      string `json:"user_id" db:"user_id"`
 	CharacterId string `json:"character_id" db:"character_id"`
+}
+
+type GearSetV2 struct {
+	Archived    bool    `json:"archived" db:"archived"`
+	ID          string  `json:"id" db:"id"`
+	Index       int     `json:"index" db:"index"`
+	Job         Job     `json:"job" db:"job"`
+	Name        string  `json:"name" db:"name"`
+	UserId      string  `json:"user_id" db:"user_id"`
+	CharacterId string  `json:"character_id" db:"character_id"`
+	Items       ItemsV2 `json:"items" db:"config"`
 }
 
 type GearSetRow struct {


### PR DESCRIPTION
Adds new gear_pieces, and gear_sets_gear_pieces tables to database

gear_pieces
| id | slot | source | have | augmented | priority |
| -- | -- | -- | -- | -- | -- |
| [pk] integer | integer | integer | boolean | boolean | integer |

gear_sets_gear_pieces
| gear_set_id | gear_piece_id | gear_piece_slot |
| -- | -- | -- |
| uuid | integer | integer |

This change deprecates the config column in the gear_set table, but historical data will remain and will be converted upon first load